### PR TITLE
Create the private nic interface file if not present

### DIFF
--- a/playbooks/common/roles/scalelab-nic-cleanup/tasks/main.yaml
+++ b/playbooks/common/roles/scalelab-nic-cleanup/tasks/main.yaml
@@ -75,30 +75,59 @@
       done
     when: "'-1029p.' in inventory_hostname"
 
-  # Make sure 10G NIC have correct IP
-  - lineinfile:
-      dest: /etc/sysconfig/network-scripts/ifcfg-{{ nic_private }}
-      regexp: "^ONBOOT="
-      line: "ONBOOT=yes"
-  - lineinfile:
-      dest: /etc/sysconfig/network-scripts/ifcfg-{{ nic_private }}
-      regexp: "^BOOTPROTO="
-      line: "BOOTPROTO=static"
-  - lineinfile:
-      dest: /etc/sysconfig/network-scripts/ifcfg-{{ nic_private }}
-      regexp: "^IPADDR="
-      line: "IPADDR={{ ip }}"
-  - lineinfile:
-      dest: /etc/sysconfig/network-scripts/ifcfg-{{ nic_private }}
-      regexp: "^NETMASK="
-      line: "NETMASK=255.0.0.0"
+  - name: Check for interface file presence
+    stat:
+      path: "/etc/sysconfig/network-scripts/ifcfg-{{ nic_private }}"
+    register: iffile_stat
 
-  # Restart network
+  - name: Create a new interface file
+    block:
+    - name: Get the MAC address of the {{ nic_private }}
+      command: cat /sys/class/net/{{ nic_private }}/address
+      register: private_nic_mac_address
+
+    - name: Build a new interface file
+      template:
+        src: templates/ifcfg-ethx.j2
+        dest: "/etc/sysconfig/network-scripts/ifcfg-{{ nic_private }}"
+        owner: root
+        group: root
+      register:
+        iffile_created
+    when:
+      iffile_stat.stat.exists == False
+
+  - name: Ensure correct config options in the already existing interface file
+    block:
+    - name: Ensure ONBOOT=yes
+      lineinfile:
+        dest: /etc/sysconfig/network-scripts/ifcfg-{{ nic_private }}
+        regexp: "^ONBOOT="
+        line: "ONBOOT=yes"
+    - name: Ensure BOOTPROTO=static
+      lineinfile:
+        dest: /etc/sysconfig/network-scripts/ifcfg-{{ nic_private }}
+        regexp: "^BOOTPROTO="
+        line: "BOOTPROTO=static"
+    - name: Ensure correct IP address
+      lineinfile:
+        dest: /etc/sysconfig/network-scripts/ifcfg-{{ nic_private }}
+        regexp: "^IPADDR="
+        line: "IPADDR={{ ip }}"
+    - name: Ensure correct netmask
+      lineinfile:
+        dest: /etc/sysconfig/network-scripts/ifcfg-{{ nic_private }}
+        regexp: "^NETMASK="
+        line: "NETMASK=255.255.0.0"
+    when: iffile_created.changed == False
+
   - name: "Kill all dhclients (network service was not restarting)"
     command:
       killall dhclient
     ignore_errors: true
+
   - name: "Restart network"
-    command:
-      service network restart
+    service:
+      name: network
+      state: restarted
 ...

--- a/playbooks/common/roles/scalelab-nic-cleanup/templates/ifcfg-ethx.j2
+++ b/playbooks/common/roles/scalelab-nic-cleanup/templates/ifcfg-ethx.j2
@@ -1,0 +1,9 @@
+NAME={{ nic_private }}
+ONBOOT=yes
+TYPE=Ethernet
+BOOTPROTO=static
+IPV6INIT=yes
+IPADDR={{ ip }}
+NETMASK=255.255.0.0
+PEERDNS=no
+HWADDR={{ private_nic_mac_address.stdout }}


### PR DESCRIPTION
Original version of this role relied on the interface file for private_nic already present. That may be the case when installing on perflab machines, but when installing on a local virtual machine with the interface file not yet created this may cause fail during the playbook run. This pull request creates the file if not present and fill it out with correct address info. If the file already exists, it will check and add the required information just like in the original version.