### PR TITLE
Dealing with "querying" when null

### DIFF
--- a/playbooks/satellite/roles/setup/tasks/main.yaml
+++ b/playbooks/satellite/roles/setup/tasks/main.yaml
@@ -19,6 +19,7 @@
   - name: "Attach to the pool"
     command:
       subscription-manager attach --pool "{{ querying.stdout_lines|first }}"
+    when: querying.stdout!=""
     register: attaching
     until: "attaching.rc == 0"
     retries: 5


### PR DESCRIPTION
Solves #82 Attaching to pool fails when the querying variable is empty.