### PR TITLE
remove/comment'h1[^>]\+>\s\+Job invocations\s\+</h1' line

### DIFF
--- a/playbooks/tests/some-webui-pages.yaml
+++ b/playbooks/tests/some-webui-pages.yaml
@@ -29,7 +29,7 @@
             fi
         done
       loop:
-                  'h1[^>]\+>\s\+Job invocations\s\+</h1'
+              #    'h1[^>]\+>\s\+Job invocations\s\+</h1'
         - uri: ''
           assert: 'h1[^>]\+>\s\+Overview\s\+</h1'
         - uri: 'job_invocations'


### PR DESCRIPTION
The playbook is failing due to the following error :

ERROR! Syntax Error while loading YAML.
  did not find expected key

The error appears to be in '/home/jenkins/agent/workspace/ContPerf67/playbooks/tests/some-webui-pages.yaml': line 33, column 9, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

                  'h1[^>]\+>\s\+Job invocations\s\+</h1'
        - uri: ''
        ^ here