### PR TITLE
linux-system-roles: Replace NTP code with timesync role

### DIFF
--- a/conf/satperf.yaml
+++ b/conf/satperf.yaml
@@ -153,6 +153,10 @@ ntp_server: clock.redhat.com
 # EPEL
 epel_release_rpm: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
 
+# Variables needed by linux-system-roles.timesync Ansible role
+timesync_ntp_servers:
+  - hostname: "{{ ntp_server }}"
+
 # Product names to be created
 tests_products: perf-gen1 perf-gen2 perf-gen3 perf-gen4 perf-gen5 perf-gen6 perf-gen7 perf-gen8
 tests_backup_path: /home/backup

--- a/playbooks/common/prepare_host.yaml
+++ b/playbooks/common/prepare_host.yaml
@@ -11,5 +11,5 @@
     - ../common/roles/remove-home-extend-root
     - ../common/roles/epel-not-present
     - ../common/roles/rhsm
-    - ../common/roles/ntp
+    - linux-system-roles.timesync
 ...

--- a/playbooks/external_dbs/setup.yaml
+++ b/playbooks/external_dbs/setup.yaml
@@ -9,7 +9,7 @@
     - ../common/roles/common
     - ../common/roles/epel-not-present
     - ../common/roles/rhsm
-    - ../common/roles/ntp
+    - linux-system-roles.timesync
     - ../common/roles/remove-home-extend-root
   tasks:
   - name: "Enable SCL repo"

--- a/playbooks/katello/installation.yaml
+++ b/playbooks/katello/installation.yaml
@@ -8,7 +8,7 @@
   roles:
     - ../common/roles/add-epel
     - ../common/roles/rhsm
-    - ../common/roles/ntp
+    - linux-system-roles.timesync
     - ../common/roles/remove-home-extend-root
     - add_rhsm_repos
     - add_katello_repos

--- a/playbooks/katello/katello_ci_installation.yaml
+++ b/playbooks/katello/katello_ci_installation.yaml
@@ -12,7 +12,7 @@
     - ../common/roles/common
     - ../common/roles/remove-home-extend-root
     - ../common/roles/enlarge-arp-table
-    - ../common/roles/ntp
+    - linux-system-roles.timesync
   tasks:
   - name: disable & enable repos
     shell: "{{ item }}"

--- a/playbooks/katello/katello_mirror_installation.yaml
+++ b/playbooks/katello/katello_mirror_installation.yaml
@@ -12,7 +12,7 @@
     - ../common/roles/common
     - ../common/roles/remove-home-extend-root
     - ../common/roles/enlarge-arp-table
-    - ../common/roles/ntp
+    - linux-system-roles.timesync
   tasks:
   - name: disable & enable repos
     shell: "{{ item }}"

--- a/playbooks/katello/katello_nightly_installation.yaml
+++ b/playbooks/katello/katello_nightly_installation.yaml
@@ -12,7 +12,7 @@
     - ../common/roles/common
     - ../common/roles/remove-home-extend-root
     - ../common/roles/enlarge-arp-table
-    - ../common/roles/ntp
+    - linux-system-roles.timesync
   tasks:
   - name: disable & enable repos
     shell: "{{ item }}"

--- a/playbooks/katello/katello_stable_installation.yaml
+++ b/playbooks/katello/katello_stable_installation.yaml
@@ -13,7 +13,7 @@
     - ../common/roles/common
     - ../common/roles/remove-home-extend-root
     - ../common/roles/enlarge-arp-table
-    - ../common/roles/ntp
+    - linux-system-roles.timesync
   tasks:
   - name: disable & enable repos
     command: "{{ item }}"

--- a/playbooks/katello/katello_stable_installation_3.14.yaml
+++ b/playbooks/katello/katello_stable_installation_3.14.yaml
@@ -13,7 +13,7 @@
     - ../common/roles/common
     - ../common/roles/remove-home-extend-root
     - ../common/roles/enlarge-arp-table
-    - ../common/roles/ntp
+    - linux-system-roles.timesync
   tasks:
   - name: disable & enable repos
     shell: "{{ item }}"

--- a/playbooks/satellite/capsules.yaml
+++ b/playbooks/satellite/capsules.yaml
@@ -10,7 +10,7 @@
     - ../common/roles/common
     - ../common/roles/epel-not-present
     - ../common/roles/rhsm-satellite
-    - ../common/roles/ntp
+    - linux-system-roles.timesync
     ###- upgrade-restart
     ###- capsule-ec2-partitioning
     - ../common/roles/remove-home-extend-root

--- a/playbooks/satellite/installation.yaml
+++ b/playbooks/satellite/installation.yaml
@@ -11,7 +11,7 @@
     - ../common/roles/common
     - ../common/roles/epel-not-present
     - ../common/roles/rhsm
-    - ../common/roles/ntp
+    - linux-system-roles.timesync
     ###- upgrade-restart
     ###- satellite-ec2-partitioning
     - ../common/roles/remove-home-extend-root


### PR DESCRIPTION
Replace the code that deals with NTP management with the `timesync`
Linux system role (available as well in RHEL System Roles).

This change will require to install the role as a dependency, and it takes
a bit more time to run, but in my opinion it's better to rely on a

> stable and consistent configuration interface to automate and manage
> multiple releases of Red Hat Enterprise Linux

As stated in [1].

[1] https://access.redhat.com/articles/3050101