### PR TITLE
linux-system-roles: Replace firewalling code with firewall role

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ You need Ansible installed.
 
 For some playbooks, you might need some "Linux system roles":
 
+    ansible-galaxy role install linux-system-roles.firewall
     ansible-galaxy role install linux-system-roles.timesync
 
 ### Configuration

--- a/playbooks/common/roles/common/tasks/main.yaml
+++ b/playbooks/common/roles/common/tasks/main.yaml
@@ -43,26 +43,6 @@
   command:
     restorecon -vR /etc/hosts
 
-# Disable firewalld
-# TODO do not disable, but configure firewalld properly
-- name: "Collect facts about system services"
-  service_facts:
-  register: services_state
-
-- name: "Disable firewalld"
-  service:
-    name: firewalld
-    state: stopped
-    enabled: no
-  when: "'firewalld.service' in services_state.ansible_facts.services"
-
-- name: "Disable iptables service"
-  service:
-    name: iptables
-    state: stopped
-    enabled: no
-  when: "'iptables.service' in services_state.ansible_facts.services"
-
 # Check SELinux
 - name: "SELinux is in Enforcing with Tragetted policy"
   selinux:

--- a/playbooks/satellite/roles/capsule/tasks/main.yaml
+++ b/playbooks/satellite/roles/capsule/tasks/main.yaml
@@ -3,6 +3,16 @@
   - assert:
       that: "capsule_install_source == 'repo' or capsule_install_source == 'cdn'"
       msg: "Capsule install source (capsule_install_source) have to be either 'repo' or 'cdn' (current value is '{{ capsule_install_source }}')"
+
+  # Configure firewall
+  - name: "Configure Capsule firewall rules"
+    ansible.builtin.import_role:
+      name: linux-system-roles.firewall
+    vars:
+      firewall:
+        - service: "RH-Satellite-6-capsule"
+          state: enabled
+
   # See https://access.redhat.com/solutions/1230493
   - name: "Make sure Satellite have Capsule in /etc/hosts"
     lineinfile:

--- a/playbooks/satellite/roles/setup/tasks/main.yaml
+++ b/playbooks/satellite/roles/setup/tasks/main.yaml
@@ -4,6 +4,15 @@
       that: "sat_install_source == 'repo' or sat_install_source == 'cdn'"
       msg: "Satellite install source (sat_install_source) have to be either 'repo' or 'cdn' (current value is '{{ sat_install_source }}')"
 
+  # Configure firewall
+  - name: "Configure Satellite firewall rules"
+    ansible.builtin.import_role:
+      name: linux-system-roles.firewall
+    vars:
+      firewall:
+        - service: "RH-Satellite-6"
+          state: enabled
+
   # We will need base RHEL and Software Collections for sure,
   # repo with Satellite packages (either custom repo or CDN repo
   # will be configured lower)


### PR DESCRIPTION
Replace the code that deals with firewalling (disabling it entirely) with
the `firewall` Linux system role (not available yet in RHEL Sytem Roles)
and document it accordingly, setting the needed rules for proper
Satellite and Capsule communication.