### PR TITLE
Allow the usage of an additional disk to store Satellite data

### DIFF
--- a/conf/satperf.yaml
+++ b/conf/satperf.yaml
@@ -10,6 +10,10 @@ timesync_ntp_servers:
     prefer: yes
     trust: yes
 
+# Partition an additional disk where all the Satellite/capsule data will be stored
+partition_new_storage: False
+storage_pools_disk: sdb
+
 # Containers setup
 containers_host_registration_options: {}
 containers_host_additional_repos: []

--- a/playbooks/common/roles/partition-new-storage/tasks/main.yaml
+++ b/playbooks/common/roles/partition-new-storage/tasks/main.yaml
@@ -1,0 +1,54 @@
+---
+- setup:
+    gather_subset:
+      - '!all'
+      - hardware
+
+# Set up required storage
+- name: "Enable rhel-7-server-optional-rpms repo (to satisfy linux-system-roles.storage role dependencies)"
+  community.general.rhsm_repository:
+    name: "rhel-{{ ansible_distribution_major_version }}-server-optional-rpms"
+  when: ansible_distribution_major_version|int == 7
+
+- name: "Set up storage requirements"
+  include_role:
+    name: linux-system-roles.storage
+
+- name: "Remove the packages required by the linux-system-roles.storage role in RHEL 7"
+  yum:
+    name: "{{ blivet_package_list }}"
+    state: absent
+    autoremove: yes
+  vars:
+    blivet_package_list:
+      - python-enum34
+      - python-blivet3
+      - libblockdev-crypto
+      - libblockdev-dm
+      - libblockdev-lvm
+      - libblockdev-mdraid
+      - libblockdev-swap
+  when: ansible_distribution_major_version|int == 7
+
+- name: "Remove the packages required by the linux-system-roles.storage role in RHEL 8"
+  yum:
+    name: "{{ blivet_package_list }}"
+    state: absent
+    autoremove: yes
+  vars:
+    blivet_package_list:
+      - python3-blivet
+      - libblockdev-crypto
+      - libblockdev-dm
+      - libblockdev-lvm
+      - libblockdev-mdraid
+      - libblockdev-swap
+      - vdo
+      - kmod-kvdo
+  when: ansible_distribution_major_version|int == 8
+
+- name: "Disable rhel-7-server-optional-rpms repo (now that it's not needed)"
+  community.general.rhsm_repository:
+    name: "rhel-7-server-optional-rpms"
+    state: disabled
+  when: ansible_distribution_major_version|int == 7

--- a/playbooks/satellite/installation.yaml
+++ b/playbooks/satellite/installation.yaml
@@ -24,6 +24,30 @@
         firewall:
           - service: "RH-Satellite-6"
             state: enabled
+    - role: ../common/roles/partition-new-storage
+      vars:
+        storage_pools:
+         - name: satellite_data
+           disks:
+             - "{{ storage_pools_disk }}"
+           volumes:
+             - name: opt
+               size: 3G
+               fs_type: xfs
+               mount_point: /opt
+             - name: postgresql
+               size: 20G
+               fs_type: xfs
+               mount_point: /var/opt/rh/rh-postgresql12
+             - name: pulp
+               size: 300G
+               fs_type: xfs
+               mount_point: /var/lib/pulp
+             - name: qpidd
+               size: 1G
+               fs_type: xfs
+               mount_point: /var/lib/qpidd
+      when: partition_new_storage is defined and partition_new_storage == True
     - role: setup
     - role: enable-remote-exec-by-ip
     - role: ../common/roles/enlarge-arp-table

--- a/requirements.yml
+++ b/requirements.yml
@@ -6,6 +6,8 @@ roles:
 
   - name: linux-system-roles.network
 
+  - name: linux-system-roles.storage
+
   - name: rhsm_helper
     src: https://github.com/jhutar/ansible-role-rhsm_helper.git
     version: origin/main


### PR DESCRIPTION
Provide a way to store most of the Satellite data in a different
disk.

To do so, set `partition_new_storage` to `True` and `storage_pools_disk`
with the value of the disk to be used, and a new VG and the required
LV and partitions will be created.

It uses the `linux-system-roles.storage` Ansible role.

Note: this code can be easily reused to implement the same funcionality
for capsules installations.