### PR TITLE
main.yaml: Replace workaround with proper solution

### DIFF
--- a/playbooks/satellite/roles/setup/tasks/main.yaml
+++ b/playbooks/satellite/roles/setup/tasks/main.yaml
@@ -1,10 +1,7 @@
 ---
-# RHEL8 workaround
-- name: "Sat 7.0 on RHEL8 workaround: dnf -y module enable ruby:2.7"
-  command: dnf -y module enable ruby:2.7
-  when: "ansible_distribution_major_version|int == 8"
-- name: "Sat 7.0 on RHEL8 workaround: dnf -y module enable pki-core"
-  command: dnf -y module enable pki-core
+# RHEL8 requirements
+- name: "Enable satellite:el8 module"
+  command: dnf -y module enable satellite:el8
   when: "ansible_distribution_major_version|int == 8"
 
 # Now, finally install required packages


### PR DESCRIPTION
Enable the `satellite:el8` module as required by the documentation.