### PR TITLE
capsules.yaml: Move roles that configure networking and resolution

### DIFF
--- a/playbooks/satellite/capsules.yaml
+++ b/playbooks/satellite/capsules.yaml
@@ -7,14 +7,14 @@
     - ../../conf/satperf.local.yaml
   roles:
     - role: ../common/roles/epel-not-present
+    - role: ../common/roles/plain-network
+    - role: ../common/roles/common
     - role: rhsm_helper
       vars:
         registration_options: "{{ capsule_registration_options }}"
     - role: repo_setup
       vars:
         additional_repos: "{{ capsule_additional_repos }}"
-    - role: ../common/roles/plain-network
-    - role: ../common/roles/common
     - role: linux-system-roles.timesync
     - role: ../common/roles/remove-home-extend-root
     - role: linux-system-roles.firewall


### PR DESCRIPTION
In the case of not being able to rely on DNS resolution, we better
have a working /etc/hosts file as soon as possible (to register against
the Satellite server, for example).