### PR TITLE
roles/capsule: Enable satellite-capsule module if needed

### DIFF
--- a/playbooks/satellite/roles/capsule/tasks/main.yaml
+++ b/playbooks/satellite/roles/capsule/tasks/main.yaml
@@ -1,4 +1,9 @@
 ---
+# RHEL8 requirements
+- name: "Enable satellite-capsule:el8 module"
+  command: dnf -y module enable satellite-capsule:el8
+  when: "ansible_distribution_major_version|int == 8"
+  
 # Install packages required for capsule
 - name: "Install capsule package"
   yum:


### PR DESCRIPTION
Enable the `satellite-capsule` module as required by the documentation.