### PR TITLE
installation.yaml: Move roles that configure networking and resolution

### DIFF
--- a/playbooks/satellite/installation.yaml
+++ b/playbooks/satellite/installation.yaml
@@ -7,14 +7,14 @@
     - ../../conf/satperf.local.yaml
   roles:
     - role: ../common/roles/epel-not-present
+    - role: ../common/roles/plain-network
+    - role: ../common/roles/common
     - role: rhsm_helper
       vars:
         registration_options: "{{ satellite_registration_options }}"
     - role: repo_setup
       vars:
         additional_repos: "{{ satellite_additional_repos }}"
-    - role: ../common/roles/plain-network
-    - role: ../common/roles/common
     - role: linux-system-roles.timesync
     - role: upgrade-restart
     ###- role: satellite-ec2-partitioning


### PR DESCRIPTION
In the case of not being able to rely on DNS resolution, we better
have a working /etc/hosts file as soon as possible (not with the same
intentions as in https://github.com/redhat-performance/satperf/pull/194,
but desirably anyway).