### PR TITLE
feat: Add ability to only configure plain network when needed

### DIFF
--- a/conf/satperf.yaml
+++ b/conf/satperf.yaml
@@ -3,6 +3,9 @@
 satperf_private_key: conf/id_rsa
 client_private_key: conf/id_rsa
 
+# Variables needed for host configuration
+configure_plain_network: True
+
 # Variables needed by linux-system-roles.timesync Ansible role
 timesync_ntp_servers:
   - hostname: "clock.redhat.com"

--- a/playbooks/satellite/capsules.yaml
+++ b/playbooks/satellite/capsules.yaml
@@ -8,6 +8,8 @@
   roles:
     - role: ../common/roles/epel-not-present
     - role: ../common/roles/plain-network
+      when:
+        - configure_plain_network == True
     - role: ../common/roles/common
     - role: rhsm_helper
       vars:

--- a/playbooks/satellite/installation.yaml
+++ b/playbooks/satellite/installation.yaml
@@ -8,6 +8,8 @@
   roles:
     - role: ../common/roles/epel-not-present
     - role: ../common/roles/plain-network
+      when:
+        - configure_plain_network == True
     - role: ../common/roles/common
     - role: rhsm_helper
       vars:


### PR DESCRIPTION
The default will be to configure it, but if it's  desired not to do so, please set:
```
configure_plain_network: False
```
in the `satperf.local.yaml` configuration file