### PR TITLE
roles/plain-network: Fix ipaddr() filter deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,12 @@ Ansible is used to perform most of the work. There are playbooks for:
 
 You need Ansible installed.
 
-For some playbooks, you might need extra roles installed:
+For some playbooks, you might need extra roles and collections installed:
 
-    ansible-galaxy role install -r requirements.yml
+```
+$ ansible-galaxy role install -r requirements.yml
+$ ansible-galaxy collection install -r requirements.yml
+```
 
 ### Configuration
 

--- a/playbooks/common/roles/plain-network/tasks/main.yaml
+++ b/playbooks/common/roles/plain-network/tasks/main.yaml
@@ -8,7 +8,7 @@
   debug:
     msg:
       - "Public network: {{ public_nic }} with DHCP"
-      - "Private network: {{ private_nic }} with {{ (private_ip + '/' + private_netmask) | ipaddr('host/prefix') }}"
+      - "Private network: {{ private_nic }} with {{ (private_ip + '/' + private_netmask) | ansible.utils.ipaddr('host/prefix') }}"
 
 - name: "Setup networking"
   include_role:
@@ -30,7 +30,7 @@
         ip:
           dhcp4: no
           address:
-            - "{{ (private_ip + '/' + private_netmask) | ipaddr('host/prefix') }}"
+            - "{{ (private_ip + '/' + private_netmask) | ansible.utils.ipaddr('host/prefix') }}"
         state: up
       - persistent_state: absent   # remove all other profiles
 ...

--- a/requirements.yml
+++ b/requirements.yml
@@ -20,5 +20,6 @@ roles:
     src: git+https://github.com/jhutar/ansible-role-sosreport_gatherer.git
     version: origin/main
 
-collections: []
+collections:
+  - name: ansible.utils
 ...


### PR DESCRIPTION
The ipaddr() filter migrated to the ansible.utils collection.