### PR TITLE
satellite/capsule: Set storage_safe_mode to False when providing storage_pools

### DIFF
--- a/playbooks/satellite/capsules.yaml
+++ b/playbooks/satellite/capsules.yaml
@@ -30,6 +30,7 @@
     - role: ../common/roles/partition-new-storage
       vars:
         storage_pools: "{{ capsule_storage_pools }}"
+        storage_safe_mode: False
       when:
         - capsule_storage_pools is defined and capsule_storage_pools|length > 0
     - role: capsule

--- a/playbooks/satellite/installation.yaml
+++ b/playbooks/satellite/installation.yaml
@@ -30,6 +30,7 @@
     - role: ../common/roles/partition-new-storage
       vars:
         storage_pools: "{{ satellite_storage_pools }}"
+        storage_safe_mode: False
       when:
         - satellite_storage_pools is defined and satellite_storage_pools|length > 0
     - role: setup


### PR DESCRIPTION
If we pass storage_pools as parameter we can safely assume that we want to overwrite any existing label.