### PR TITLE
ansible.cfg: Fix callback_whitelist deprecation warning

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,4 +2,4 @@
 forks = 10
 host_key_checking = False
 inventory = conf/hosts.ini
-callback_whitelist = profile_tasks
+callbacks_enabled = profile_tasks


### PR DESCRIPTION
[DEPRECATION WARNING]: [defaults]callback_whitelist option, normalizing names  to new standard, use callbacks_enabled instead. This feature will be removed  from ansible-core in version 2.15.