### PR TITLE
feat: Add new registration method: 'clients_host-registration'

### DIFF
--- a/playbooks/satellite/clients_host-registration.yaml
+++ b/playbooks/satellite/clients_host-registration.yaml
@@ -1,0 +1,25 @@
+---
+- hosts: all
+  remote_user: root
+  gather_facts: no
+  tasks:
+    - name: Cleanup
+      shell:
+        rm -rf /etc/yum.repos.d/*.repo
+
+    - name: Register
+      ansible.builtin.script:
+        cmd: /root/clients_host-registration.sh 2>&1 | tee /root/registration.log
+      register: reg
+
+    - name: "Register - output"
+      debug:
+        msg:
+          - "{{ reg.stdout }}"
+          - "{{ reg.stderr }}"
+
+    - name: "Register - timings"
+      debug:
+        msg="Register {{ reg.start }} to {{ reg.end }}"
+      when: "reg.rc == 0"
+...

--- a/playbooks/satellite/host-registration_generate-command.yaml
+++ b/playbooks/satellite/host-registration_generate-command.yaml
@@ -1,0 +1,33 @@
+---
+- hosts: satellite6:capsules
+  remote_user: root
+  gather_facts: no
+  vars_files:
+    - ../../conf/satperf.yaml
+    - ../../conf/satperf.local.yaml
+  vars:
+    hgrg: "host-registration generate-command --organization-id {{ sat_orgid }} --activation-key {{ ak }} --insecure true --force true"
+  tasks:
+    - name: "Check if running in a capsule"
+      ansible.builtin.set_fact:
+        hgrg: "{{ hgrg }} --smart-proxy {{ inventory_hostname }}"
+      when: "'capsules' in group_names"
+
+    - name: "Check if MQTT REX mode is needed"
+      ansible.builtin.set_fact:
+        hgrg: "{{ hgrg }} --setup-remote-execution-pull true"
+      when: "hostvars[inventory_hostname].rex_mode is defined and hostvars[inventory_hostname].rex_mode == 'mqtt'"
+
+    - name: "Generate the host registration command"
+      ansible.builtin.command:
+        hammer -u {{ sat_user}} -p {{ sat_pass }} {{ hgrg }}
+      register: cmd
+      delegate_to: "{{ groups['satellite6'] | first }}"
+
+    - name: Copy the output of the the host registration command to the Apache pub directory
+      ansible.builtin.copy:
+        content: "{{ cmd.stdout }}"
+        dest: "/var/www/html/pub/host-registration_{{ inventory_hostname }}.sh"
+      delegate_to: "{{ groups['satellite6'] | first }}"
+      when: "cmd.rc == 0"
+...

--- a/playbooks/satellite/roles/client-scripts/files/clients_host-registration.yaml.j2
+++ b/playbooks/satellite/roles/client-scripts/files/clients_host-registration.yaml.j2
@@ -1,0 +1,27 @@
+{% raw %}
+---
+- hosts: all
+  remote_user: root
+  gather_facts: no
+  tasks:
+    - name: Cleanup
+      shell:
+        rm -rf /etc/yum.repos.d/*.repo
+
+    - name: Register
+      ansible.builtin.script:
+        cmd: /root/clients_host-registration.sh 2>&1 | tee /root/registration.log
+      register: reg
+
+    - name: "Register - output"
+      debug:
+        msg:
+          - "{{ reg.stdout }}"
+          - "{{ reg.stderr }}"
+
+    - name: "Register - timings"
+      debug:
+        msg="Register {{ reg.start }} to {{ reg.end }}"
+      when: "reg.rc == 0"
+...
+{% endraw %}

--- a/playbooks/satellite/roles/client-scripts/tasks/main.yaml
+++ b/playbooks/satellite/roles/client-scripts/tasks/main.yaml
@@ -67,6 +67,7 @@
     - "clients.yaml"
     - "clients-register.yaml"
     - "clients-bootstrap.yaml"
+    - "clients_host-registration.yaml"
 
 - name: "Install Ansible"
   package:

--- a/playbooks/tests/registrations.yaml
+++ b/playbooks/tests/registrations.yaml
@@ -40,6 +40,24 @@
         clients_yaml_cmd_log: "/root/out-{{ lookup('pipe', 'date --utc --iso-8601=seconds') | regex_replace('[^A-Za-z0-9-]', '_') }}.log"
       run_once: yes
 
+    - name: "Download host registration script from Satellite"
+      ansible.builtin.get_url:
+        url: http://{{ groups['satellite6'] | first }}/pub/host-registration_{{ tests_registration_target }}.sh
+        dest: /root/clients_host-registration.sh
+      when: "method == 'clients_host-registration'"
+
+    - name: "Run clients_host-registration.yaml (log = {{ clients_yaml_cmd_log }})"
+      shell: |
+        ansible-playbook \
+          --private-key /root/id_rsa_key \
+          --forks "{{ size }}" \
+          -i clients.ini \
+          clients_host-registration.yaml \
+          &> "{{ clients_yaml_cmd_log }}"
+      register: clients_yaml_cmd
+      ignore_errors: true
+      when: "method == 'clients_host-registration'"
+
     - name: "Run clients.yaml (log = {{ clients_yaml_cmd_log }})"
       shell: |
         ansible-playbook \


### PR DESCRIPTION
This code can be tested the following way:

- Create the registration commands for each capsule (Satellite included):
`playbooks/satellite/host-registration_generate-command.yaml -e "ak=${YOUR_ACTIVATION_KEY}"'
`

- Register the content hosts:
`playbooks/tests/registrations.yaml -e "method=clients_host-registration"
`