### PR TITLE
fix: capsule: Fail hard if capsule configuration fails

### DIFF
--- a/playbooks/satellite/roles/capsule/tasks/main.yaml
+++ b/playbooks/satellite/roles/capsule/tasks/main.yaml
@@ -110,9 +110,6 @@
     LANG: "en_US.UTF-8"
     LC_ALL: "en_US.UTF-8"
   register: configuration
-  until: "configuration.rc == 0"
-  retries: 5
-  delay: 10
 
 - name: "Show Capsule configuration output"
   ansible.builtin.debug:


### PR DESCRIPTION
Retrying the configuration after a failure can hide a misconfigured capsule and lead to duplicated host entries.